### PR TITLE
Fix "Sorry, that site is reserved!" error when adding a site with slug same as your username.

### DIFF
--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -421,10 +421,10 @@ add_action("pmpro_paypalexpress_session_vars", "pmpron_pmpro_paypalexpress_sessi
 //require the fields and check for dupes
 function pmpron_pmpro_registration_checks($pmpro_continue_registration)
 {
-	if ( !$pmpro_continue_registration )
-		return $pmpro_continue_registration;
-
 	global $pmpro_msg, $pmpro_msgt, $current_site, $current_user, $pmpro_network_non_site_levels, $pmpro_level;
+	
+	if ( !$pmpro_continue_registration )
+		return $pmpro_continue_registration;	
 	
 	if(!empty($_REQUEST['sitename']))
 		$sitename = $_REQUEST['sitename'];

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -454,7 +454,7 @@ function pmpron_pmpro_registration_checks($pmpro_continue_registration)
 	}
 		
 	if( !empty($sitename) && !empty($sitetitle) ) {
-		if(pmpron_checkSiteName( $sitename, $sitetitle ) ) {
+		if(pmpron_checkSiteName( $sitename, $sitetitle, $current_user ) ) {
 			//all good
 			return $pmpro_continue_registration;	
 		} else {
@@ -484,9 +484,16 @@ add_filter( 'pmpro_registration_checks', 'pmpron_pmpro_registration_checks' );
 /*
 	Checks if a domain/site name is available.
 */
-function pmpron_checkSiteName( $sitename, $sitetitle )
+function pmpron_checkSiteName( $sitename, $sitetitle, $user = null )
 {
-	$result = wpmu_validate_blog_signup( $sitename, $sitetitle );
+	global $current_user;
+	
+	// assume Current User
+	if ( empty( $user ) ) {
+		$user = $current_user;
+	}
+	
+	$result = wpmu_validate_blog_signup( $sitename, $sitetitle, $user );
 	$errors = $result['errors']->get_error_messages();
 	if( empty( $errors ) ) {
 		return true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-network/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-network/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The wpmu_validate_blog_signup() function can take a 3rd parameter for the user adding the site. This is used, among other things, to make sure users don't create sites with slugs equal to existing usernames UNLESS they are that user.

Our pmpron_checkSiteName() function now passes the current_user into the wpmu_validate_blog_signup() call so users can create sites with their own username.

### How to test the changes in this Pull Request:

1. Have site credits. Visit the manage sites page.
2. Add a site with a slug the same as the current user's username. (You may have to delete a site -carefully- if it already exists.)
3. The site should be added after applying this patch. Before, it would throw an error.

### Other information:

IMPORTANT NOTE: This issues brings up a related question, which is "why wasn't this error happening if a user chose a sitename same as their username at checkout?" I think the answer is that we aren't doing the wpmu_validate_blog_signup() check at checkout. We should test and look into calling our pmpron_checkSiteName() before creating sites at checkout.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed "Sorry, that site is reserved!" error when adding a site with slug same as your username.
