### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -75,8 +75,9 @@ function pmpron_pmpro_checkout_boxes()
 	$level_id = null;
 
 	// Get the level info
-	if (isset($_REQUEST['level'])) {
-		$level_id = intval($_REQUEST['level']);
+	$level = pmpro_getLevelAtCheckout();
+	if ( ! empty( $level->id ) ) {
+		$level_id = intval( $level->id );
 	}
 
 	// Return if requested level is in non site levels array


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.