### PR TITLE
Add user site credits to member edit page

### DIFF
--- a/classes/pmpron-class-member-edit-panel-fields.php
+++ b/classes/pmpron-class-member-edit-panel-fields.php
@@ -1,0 +1,76 @@
+<?php
+
+defined( 'ABSPATH' ) || die( 'File cannot be accessed directly' );
+
+/**
+ * Class PMPro_N_fields_update
+ */
+class PMPro_N_fields_update  extends PMPro_Member_Edit_Panel {
+
+	/**
+	 * Set up the panel.
+	 */
+	public function __construct() {
+		$this->slug = 'pmpro-network';
+		$this->title = __( 'Site Credits', 'pmpro-network' );
+	}
+
+	/**
+	 * Display the panel contents.
+	 *
+	 * @since TBD
+	 * return void
+	 */
+	protected function display_panel_contents() {
+		// Get the user being edited.
+		$user = self::get_user();
+
+		//Bail if user can't manage network
+		if( ! current_user_can( 'manage_network' ) ) {
+			return;
+		}
+
+		// Get the user's site credits.
+		$all_blog_ids = pmpron_getBlogsForUser( $user->ID );
+		$num = count( $all_blog_ids );
+		$site_credits = $user->pmpron_site_credits;
+		?>
+		<table class="form-table">
+			<tr>
+				<th><label for="site_credits"><?php esc_html_e( 'Site Credits', 'pmpro-network' ); ?></label></th>
+				<td>
+					<input type="number" id="site_credits" name="site_credits" size="5" value="<?php echo esc_attr( $site_credits ); ?>" />
+					<p class="description"><?php echo esc_html( sprintf( __( 'currently using %s', 'pmpro-network' ), $num ) ); ?></p>
+				</td>
+			</tr>
+		</table>
+		<p class="submit">
+			<button class="button button-primary" type="submit"><?php esc_html_e( 'Update', 'pmpro-network' ); ?></button>
+		</p>
+	<?php
+	}
+
+	/**
+	 * Save the panel.
+	 *
+	 * @since TBD
+	 * return void
+	 */
+	public function save() {
+		// Get the user being edited.
+		$user = self::get_user();
+
+		//Bail if user can't manage network
+		if( ! current_user_can( 'manage_network' ) ) {
+			return;
+		}
+
+		// Get the site credits.
+		$site_credits = isset( $_POST['site_credits'] ) ? intval( $_POST['site_credits'] ) : 0;
+
+		// Update the user's site credits.
+		update_user_meta( $user->ID, 'pmpron_site_credits', $site_credits );
+		//Show a success message
+		pmpro_setMessage( __( 'Site credits updated.', 'pmpro-network' ), 'pmpro_success' );
+	}
+}

--- a/classes/pmpron-class-member-edit-panel-site-credits.php
+++ b/classes/pmpron-class-member-edit-panel-site-credits.php
@@ -2,16 +2,13 @@
 
 defined( 'ABSPATH' ) || die( 'File cannot be accessed directly' );
 
-/**
- * Class PMPro_N_fields_update
- */
-class PMPro_N_fields_update  extends PMPro_Member_Edit_Panel {
+class PMPron_Member_Edit_Panel_Site_Credits extends PMPro_Member_Edit_Panel {
 
 	/**
 	 * Set up the panel.
 	 */
 	public function __construct() {
-		$this->slug = 'pmpro-network';
+		$this->slug = 'site-credits';
 		$this->title = __( 'Site Credits', 'pmpro-network' );
 	}
 
@@ -19,16 +16,15 @@ class PMPro_N_fields_update  extends PMPro_Member_Edit_Panel {
 	 * Display the panel contents.
 	 *
 	 * @since TBD
-	 * return void
 	 */
 	protected function display_panel_contents() {
-		// Get the user being edited.
-		$user = self::get_user();
-
-		//Bail if user can't manage network
-		if( ! current_user_can( 'manage_network' ) ) {
+		// Bail if user can't manage the network.
+		if ( ! current_user_can( 'manage_network' ) ) {
 			return;
 		}
+
+		// Get the user being edited.
+		$user = self::get_user();
 
 		// Get the user's site credits.
 		$all_blog_ids = pmpron_getBlogsForUser( $user->ID );
@@ -47,30 +43,30 @@ class PMPro_N_fields_update  extends PMPro_Member_Edit_Panel {
 		<p class="submit">
 			<button class="button button-primary" type="submit"><?php esc_html_e( 'Update', 'pmpro-network' ); ?></button>
 		</p>
-	<?php
+		<?php
 	}
 
 	/**
 	 * Save the panel.
 	 *
 	 * @since TBD
-	 * return void
 	 */
 	public function save() {
-		// Get the user being edited.
-		$user = self::get_user();
-
-		//Bail if user can't manage network
-		if( ! current_user_can( 'manage_network' ) ) {
+		// Bail if user can't manage the network.
+		if ( ! current_user_can( 'manage_network' ) ) {
 			return;
 		}
+
+		// Get the user being edited.
+		$user = self::get_user();
 
 		// Get the site credits.
 		$site_credits = isset( $_POST['site_credits'] ) ? intval( $_POST['site_credits'] ) : 0;
 
 		// Update the user's site credits.
 		update_user_meta( $user->ID, 'pmpron_site_credits', $site_credits );
-		//Show a success message
+
+		// Show a success message.
 		pmpro_setMessage( __( 'Site credits updated.', 'pmpro-network' ), 'pmpro_success' );
 	}
 }

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -746,28 +746,27 @@ function pmpron_myblogs_allblogs_options()
 add_action( 'myblogs_allblogs_options', 'pmpron_myblogs_allblogs_options' );
 
 /**
- * Add a panel to the Edit Member dashboard page.
+ * Add the Site Credits panel to the Edit Member dashboard page.
  *
  * @since TBD
  *
  * @param array $panels Array of panels.
  * @return array Array of panels.
-
  */
-function pmpron_member_edit_panels_reasons( $panels ) {
+function pmpron_member_edit_panels( $panels ) {
 	// If the class doesn't exist and the abstract class does, require the class.
-	if ( ! class_exists( 'PMPro_N_fields_update' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
-		require_once( dirname( __FILE__ ) . '/classes/pmpron-class-member-edit-panel-fields.php' );
+	if ( ! class_exists( 'PMPron_Member_Edit_Panel_Site_Credits' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+		require_once( dirname( __FILE__ ) . '/classes/pmpron-class-member-edit-panel-site-credits.php' );
 	}
 
 	// If the class exists, add a panel.
-	if ( class_exists( 'PMPro_N_fields_update' ) ) {
-		$panels[] = new PMPro_N_fields_update();
+	if ( class_exists( 'PMPron_Member_Edit_Panel_Site_Credits' ) ) {
+		$panels[] = new PMPron_Member_Edit_Panel_Site_Credits();
 	}
 
 	return $panels;
 }
-add_filter( 'pmpro_member_edit_panels', 'pmpron_member_edit_panels_reasons' );
+add_filter( 'pmpro_member_edit_panels', 'pmpron_member_edit_panels' );
 
 /*
 	When a site is deleted, free up the site credit and blog id

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -745,52 +745,29 @@ function pmpron_myblogs_allblogs_options()
 }
 add_action( 'myblogs_allblogs_options', 'pmpron_myblogs_allblogs_options' );
 
-/*
-	Add site credits field to profile for admins to adjust
-*/
-//show fields
-function pmpron_profile_fields($profile_user)
-{	
-	if(current_user_can("manage_network"))
-	{		
-	?>
-		<h2><?php esc_html_e( 'Site Credits', 'pmpro-network' ); ?></h2>
-		<table class="form-table">
-		<tr>
-			<th><label for="site_credits"><?php esc_html_e( 'Site Credits', 'pmpro-network' ); ?></label></th>
-			<td>
-				<?php
-					//how many sites have they created?	
-					$all_blog_ids = pmpron_getBlogsForUser($profile_user->ID);	
-					$num = count($all_blog_ids);
-						
-					//how many can they create?
-					$site_credits = $profile_user->pmpron_site_credits;						
-				?>
-				<input type="text" id="site_credits" name="site_credits" size="5" value="<?php echo esc_attr( $site_credits ); ?>" /> <em><?php echo esc_html( sprintf( __( 'currently using %s', 'pmpro-network' ), $num ) ); ?></em>
+/**
+ * Add a panel to the Edit Member dashboard page.
+ *
+ * @since TBD
+ *
+ * @param array $panels Array of panels.
+ * @return array Array of panels.
 
-			</td>
-		</tr>
-		</table>
-	<?php
+ */
+function pmpron_member_edit_panels_reasons( $panels ) {
+	// If the class doesn't exist and the abstract class does, require the class.
+	if ( ! class_exists( 'PMPro_N_fields_update' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+		require_once( dirname( __FILE__ ) . '/classes/pmpron-class-member-edit-panel-fields.php' );
 	}
-}
-add_action( 'show_user_profile', 'pmpron_profile_fields' );
-add_action( 'edit_user_profile', 'pmpron_profile_fields' );
 
-//save fields
-function pmpron_profile_fields_update($user_id)
-{
-	//make sure they can edit
-	if ( !current_user_can( 'manage_network') )
-		return false;
+	// If the class exists, add a panel.
+	if ( class_exists( 'PMPro_N_fields_update' ) ) {
+		$panels[] = new PMPro_N_fields_update();
+	}
 
-	//if site credits is there, set it
-	if(isset($_POST['site_credits']))
-		update_user_meta( $user_id, 'pmpron_site_credits', intval($_POST['site_credits']) );	
+	return $panels;
 }
-add_action( 'profile_update', 'pmpron_profile_fields_update' );
-add_action( 'user_edit_form_tag', 'pmpron_profile_fields_update' );
+add_filter( 'pmpro_member_edit_panels', 'pmpron_member_edit_panels_reasons' );
 
 /*
 	When a site is deleted, free up the site credit and blog id


### PR DESCRIPTION
 ENHACEMENT: Add Site Credit panel for v3.1 compat sake

<img width="853" alt="image" src="https://github.com/user-attachments/assets/1d1e0309-08c3-4345-a80d-d776681a232e">

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-network/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-network/pulls/) for the same update/change?


### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
