### PR TITLE
Support offsite gateways and delayed checkout

### DIFF
--- a/pages/manage-sites.php
+++ b/pages/manage-sites.php
@@ -43,7 +43,7 @@ function pmpron_manage_sites_shortcode($atts, $content=null, $code="") {
 
 		if ( pmpron_checkSiteName( $sitename, $sitetitle ) ) {
 			$blog_id = pmpron_addSite( $sitename, $sitetitle );
-			if ( is_wp_error( $blog_id ) ) {
+			if ( is_wp_error( $blog_id ) || empty( $blog_id ) ) {
 				$pmpro_msg = __( 'Error creating site.', 'pmpro-network' );
 				$pmpro_msgt = "pmpro_error";
 			} else {

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -390,8 +390,9 @@ add_action( 'pmpro_membership_level_after_other_settings', 'pmpron_pmpro_members
  *
  * @param string $sitename  The name of the site to add.
  * @param string $sitetitle The title of the site to add.
+ * @param int    $user_id   The user ID.
  *
- * @return bool|WP_Error The blog id of the site on success, WP_Error on failure.
+ * @return mixed blog id (int) on success, WP_Error on blog creation failure, false if no valid user.
  */
 function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 	global $current_user, $current_site;
@@ -401,6 +402,11 @@ function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 		$user = $current_user;
 	} else {
 		$user = get_userdata( $user_id );
+	}
+
+	// No user, bail.
+	if ( empty( $user ) ) {
+		return false;
 	}
 
 	// Figure out the new domain.

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -207,15 +207,16 @@ function pmpron_pmpro_added_order( $order ) {
 	$sitetitle = ! empty( $_REQUEST['sitetitle'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitetitle'] ) ) : '';
 	$blog_id   = ! empty( $_REQUEST['blog_id'] ) ? absint( $_REQUEST['blog_id'] ) : '';
 
-	// Missing network site checkout params, bail.
-	if ( empty( $sitename ) && empty( $blog_id ) ) {
-		return;
-	}
-
 	// Save site details to order meta for use later.
-	update_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', $sitename );
-	update_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', $sitetitle );
-	update_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', $blog_id );
+	if ( ! empty( $sitename ) ) {
+		update_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', $sitename );
+	}
+	if ( ! empty( $sitetitle ) ) {
+		update_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', $sitetitle );
+	}
+	if ( ! empty( $blog_id ) ) {
+		update_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', $blog_id );
+	}
 }
 add_action( 'pmpro_added_order', 'pmpron_pmpro_added_order' );
 

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -182,6 +182,43 @@ function pmpron_pmpro_checkout_boxes()
 }
 add_action('pmpro_checkout_boxes', 'pmpron_pmpro_checkout_boxes');
 
+/**
+ * Save site details to order meta when an order is added for a network site level.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order object.
+ */
+function pmpron_pmpro_added_order( $order ) {
+	global $current_user, $pmpro_network_non_site_levels;
+
+	// If we don't have an order, bail.
+	if ( empty( $order ) || empty( $order->id ) ) {
+		return;
+	}
+
+	// If the order level is not set or is in the non site levels array, bail.
+	if ( empty( $order->membership_id ) || in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) {
+		return;
+	}
+
+	// Get site name, site title, and blog id from request.
+	$sitename  = ! empty( $_REQUEST['sitename'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitename'] ) ) : '';
+	$sitetitle = ! empty( $_REQUEST['sitetitle'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitetitle'] ) ) : '';
+	$blog_id   = ! empty( $_REQUEST['blog_id'] ) ? absint( $_REQUEST['blog_id'] ) : '';
+
+	// Missing network site checkout params, bail.
+	if ( empty( $sitename ) && empty( $blog_id ) ) {
+		return;
+	}
+
+	// Save site details to order meta for use later.
+	update_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', $sitename );
+	update_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', $sitetitle );
+	update_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', $blog_id );
+}
+add_action( 'pmpro_added_order', 'pmpron_pmpro_added_order' );
+
 //update the user after checkout
 function pmpron_update_site_after_checkout( $user_id, $order )
 {

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -457,18 +457,6 @@ function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 	return $blog_id;
 }
 
-/*
-These bits are required for PayPal Express only.
-*/
-function pmpron_pmpro_paypalexpress_session_vars()
-{
-	//save our added fields in session while the user goes off to PayPal
-	$_SESSION['sitename'] = $_REQUEST['sitename'];
-	$_SESSION['sitetitle'] = $_REQUEST['sitetitle'];
-	$_SESSION['blog_id'] = $_REQUEST['blog_id'];
-}
-add_action("pmpro_paypalexpress_session_vars", "pmpron_pmpro_paypalexpress_session_vars");
-
 //require the fields and check for dupes
 function pmpron_pmpro_registration_checks($pmpro_continue_registration)
 {

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -219,70 +219,60 @@ function pmpron_pmpro_added_order( $order ) {
 }
 add_action( 'pmpro_added_order', 'pmpron_pmpro_added_order' );
 
-//update the user after checkout
-function pmpron_update_site_after_checkout( $user_id, $order )
-{
-	global $current_user, $current_site, $pmpro_network_non_site_levels;	
-	
-	if(isset($_REQUEST['sitename']))
-	{   
-		//new site, on-site checkout
-		$sitename = $_REQUEST['sitename'];
-		$sitetitle = $_REQUEST['sitetitle'];
-		if(!empty($_REQUEST['blog_id']))
-			$blog_id = intval($_REQUEST['blog_id']);
+/**
+ * Update the user after checkout
+ *
+ * @since unknown
+ * @since TBD Fetching site details from order meta instead of request/session
+ *
+ * @param int         $user_id The ID of the user who completed checkout.
+ * @param MemberOrder $order The order object.
+ */
+function pmpron_update_site_after_checkout( $user_id, $order ) {
+	global $current_user, $current_site, $pmpro_network_non_site_levels;
+
+	// If we don't have an order, bail.
+	if ( empty( $order ) || empty( $order->id ) ) {
+		return;
 	}
-	elseif(isset($_REQUEST['blog_id']))
-	{
-		//reclaiming, on-site checkout
-		$blog_id = intval($_REQUEST['blog_id']);
+
+	// Membership level ID not set, or completed checkout is for a non-network site level, bail.
+	if ( empty( $order->membership_id ) || in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) {
+		return;
 	}
-	elseif(isset($_SESSION['sitename']))
-	{   
-		//new site, off-site checkout
-		$sitename = $_SESSION['sitename'];
-		$sitetitle = $_SESSION['sitetitle'];
-		if(!empty($_SESSION['blog_id']))
-			$blog_id = intval($_SESSION['blog_id']);
-	}	
-	elseif(isset($_SESSION['blog_id']))
-	{
-		//reclaiming, off-site checkout
-		$blog_id = intval($_SESSION['blog_id']);
+
+	// Pull site details from order.
+	$sitename  = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', true );
+	$sitetitle = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', true );
+	$blog_id   = get_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', true );
+
+	// No network site details in the order, bail.
+	if ( empty( $sitename ) && empty( $blog_id ) ) {
+		return;
 	}
-	
-	$r = false;		//default return value
-	
-	if(!empty($blog_id))
-	{
-		//reclaiming, first check that this id is associated with the user	
-		$all_blog_ids = pmpron_getBlogsForUser($user_id);
-		if(in_array($blog_id, $all_blog_ids))
-		{
-			//activate the blog
+
+	if ( ! empty( $blog_id ) ) {
+		// Reclaiming, first check that this id is associated with the user.
+		$all_blog_ids = pmpron_getBlogsForUser( $user_id );
+		if ( in_array( $blog_id, $all_blog_ids ) ) {
+			// Activate the blog.
 			update_blog_status( $blog_id, 'deleted', '0' );
 			do_action( 'activate_blog', $blog_id );
-			$r = true;
-		}		
-		else
-		{
-			//uh oh, were they trying to claim someone else's blog?
-			$r = new WP_Error('pmpron_reactivation_failed', __('<strong>ERROR</strong>: Site reactivation failed.'));			
+		} else {
+			// Someone else's blog, not reactivated. Write to order notes.
+			/* translators: %d: Numeric Blog ID. */
+			$order->notes .= sprintf( __( 'Site reactivation failed. Blog ID: %d.', 'pmpro-network' ), $blog_id );
+			$order->saveOrder();
+		}
+	} elseif ( pmpron_getSiteCredits( $order->membership_id ) > 0 ) {
+		$blog_id = pmpron_addSite( $sitename, $sitetitle, $user_id );
+		if ( is_wp_error( $blog_id ) ) {
+			// Error activating the blog. Write to order notes.
+			/* translators: %1$s: Network Site Name, %2$s: Network Site Title. */
+			$order->notes .= sprintf( __( 'Site creation failed. Site Name: %1$s. Site Title: %2$s.', 'pmpro-network' ), $sitename, $sitetitle );
+			$order->saveOrder();
 		}
 	}
-	elseif( ! empty( $order->membership_id ) && ! in_array( $order->membership_id, $pmpro_network_non_site_levels ) && pmpron_getSiteCredits( $order->membership_id ) > 0 )
-	{
-		$blog_id = pmpron_addSite($sitename, $sitetitle);
-		if(is_wp_error($blog_id))
-			$r = $blog_id;
-	}
-	
-	//clear session vars
-	unset($_SESSION['sitename']);
-	unset($_SESSION['sitetitle']);
-	unset($_SESSION['blog_id']);
-	
-	return $r;
 }
 add_action( 'pmpro_after_checkout', 'pmpron_update_site_after_checkout', 10, 2 );
 

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -91,8 +91,8 @@ function pmpron_pmpro_checkout_boxes()
 	
 	if(!empty($_REQUEST['sitename']))
 	{
-		$sitename = $_REQUEST['sitename'];
-		$sitetitle = $_REQUEST['sitetitle']; 
+		$sitename  = sanitize_text_field( wp_unslash( $_REQUEST['sitename'] ) );
+		$sitetitle = sanitize_text_field( wp_unslash( $_REQUEST['sitetitle'] ) );
 	}
     else {
         $sitename = '';

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -392,53 +392,68 @@ function pmpron_pmpro_membership_level_after_other_settings() {
 }
 add_action( 'pmpro_membership_level_after_other_settings', 'pmpron_pmpro_membership_level_after_other_settings' );
 
-/*
-	Function to add a site.
-	Takes sitename and sitetitle
-	Returns blog_id
-*/
-function pmpron_addSite($sitename, $sitetitle)
-{
+/**
+ * Function to add a site.
+ *
+ * @since unknown
+ * @since TBD Added $user_id arg.
+ *
+ * @param string $sitename  The name of the site to add.
+ * @param string $sitetitle The title of the site to add.
+ *
+ * @return bool|WP_Error The blog id of the site on success, WP_Error on failure.
+ */
+function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 	global $current_user, $current_site;
-		
-	//figure out the new domain	
+
+	// If no user ID was provided, default to the current user.
+	if ( empty( $user_id ) ) {
+		$user = $current_user;
+	} else {
+		$user = get_userdata( $user_id );
+	}
+
+	// Figure out the new domain.
 	$site_domain = preg_replace( '|^www\.|', '', $current_site->domain );
 
-	if ( !is_subdomain_install() )
-	{
+	if ( ! is_subdomain_install() ) {
 		$site = $current_site->domain;
 		$path = $current_site->path . $sitename;
-	}
-	else
-	{
+	} else {
 		$site = $sitename . '.' . $site_domain;
 		$path = $current_site->path;
 	}
 
-	//alright create the blog
-	$meta = apply_filters('signup_create_blog_meta', array ('lang_id' => 'en', 'public' => 0));
-	$blog_id = wpmu_create_blog($site, $path, $sitetitle, $current_user->ID, $meta);
-	
-	do_action("pmpro_network_new_site", $blog_id, $current_user->ID);
+	// Alright create the blog.
+	$meta    = apply_filters(
+		'signup_create_blog_meta',
+		array(
+			'lang_id' => 'en',
+			'public'  => 0,
+		)
+	);
+	$blog_id = wpmu_create_blog( $site, $path, $sitetitle, $user->ID, $meta );
 
-	if ( is_a($blog_id, "WP_Error") ) {
-		return new WP_Error('blogcreate_failed', __('<strong>ERROR</strong>: Site creation failed.'));
+	do_action( 'pmpro_network_new_site', $blog_id, $user->ID );
+
+	if ( is_a( $blog_id, 'WP_Error' ) ) {
+		return new WP_Error( 'blogcreate_failed', __( '<strong>ERROR</strong>: Site creation failed.' ) );
 	}
-			
-	//save array of all blog ids
-	$blog_ids = pmpron_getBlogsForUser($current_user->ID);	
-	if(!in_array($blog_id, $blog_ids))
-	{
+
+	// Save array of all blog ids.
+	$blog_ids = pmpron_getBlogsForUser( $user->ID );
+	if ( ! in_array( $blog_id, $blog_ids ) ) {
 		$blog_ids[] = $blog_id;
-		update_user_meta($current_user->ID, "pmpron_blog_ids", $blog_ids);
-		
-		//if this is the first site, set it as the main site
-		if(count($blog_ids) == 1)
-			update_user_meta($current_user->ID, "pmpron_blog_id", $blog_id);	
-	}				
-	
-	do_action('wpmu_activate_blog', $blog_id, $current_user->ID, $current_user->user_pass, $sitetitle, $meta);
-	
+		update_user_meta( $user->ID, 'pmpron_blog_ids', $blog_ids );
+
+		// If this is the first site, set it as the main site.
+		if ( count( $blog_ids ) === 1 ) {
+			update_user_meta( $user->ID, 'pmpron_blog_id', $blog_id );
+		}
+	}
+
+	do_action( 'wpmu_activate_blog', $blog_id, $user->ID, $user->user_pass, $sitetitle, $meta );
+
 	return $blog_id;
 }
 

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -205,7 +205,7 @@ function pmpron_pmpro_added_order( $order ) {
 	// Get site name, site title, and blog id from request.
 	$sitename  = ! empty( $_REQUEST['sitename'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitename'] ) ) : '';
 	$sitetitle = ! empty( $_REQUEST['sitetitle'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitetitle'] ) ) : '';
-	$blog_id   = ! empty( $_REQUEST['blog_id'] ) ? absint( $_REQUEST['blog_id'] ) : '';
+	$blog_id   = ! empty( $_REQUEST['blog_id'] ) ? absint( $_REQUEST['blog_id'] ) : 0;
 
 	// Save site details to order meta for use later.
 	if ( ! empty( $sitename ) ) {
@@ -432,7 +432,7 @@ function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 	$blog_id = wpmu_create_blog( $site, $path, $sitetitle, $user->ID, $meta );
 
 	if ( is_a( $blog_id, 'WP_Error' ) ) {
-		return new WP_Error( 'blogcreate_failed', __( '<strong>ERROR</strong>: Site creation failed.', 'pmpro_network' ) );
+		return new WP_Error( 'blogcreate_failed', __( '<strong>ERROR</strong>: Site creation failed.', 'pmpro-network' ) );
 	}
 
 	do_action( 'pmpro_network_new_site', $blog_id, $user->ID );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -94,11 +94,6 @@ function pmpron_pmpro_checkout_boxes()
 		$sitename = $_REQUEST['sitename'];
 		$sitetitle = $_REQUEST['sitetitle']; 
 	}
-	elseif(!empty($_SESSION['sitename']))
-	{
-		$sitename = $_SESSION['sitename'];
-		$sitetitle = $_SESSION['sitetitle']; 
-	}
     else {
         $sitename = '';
         $sitetitle = '';

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -261,7 +261,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 		} else {
 			// Someone else's blog, not reactivated. Write to order notes.
 			/* translators: %d: Numeric Blog ID. */
-			$order->notes .= sprintf( __( 'Site reactivation failed. Blog ID: %d.', 'pmpro-network' ), $blog_id );
+			$order->notes .= sprintf( __( 'Site reactivation failed. Blog ID: %d.', 'pmpro-network' ), $blog_id ) . "\n";
 			$order->saveOrder();
 		}
 	} elseif ( pmpron_getSiteCredits( $order->membership_id ) > 0 ) {
@@ -269,7 +269,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 		if ( is_wp_error( $blog_id ) || empty( $blog_id ) ) {
 			// Error activating the blog. Write to order notes.
 			/* translators: %1$s: Network Site Name, %2$s: Network Site Title. */
-			$order->notes .= sprintf( __( 'Site creation failed. Site Name: %1$s. Site Title: %2$s.', 'pmpro-network' ), $sitename, $sitetitle );
+			$order->notes .= sprintf( __( 'Site creation failed. Site Name: %1$s. Site Title: %2$s.', 'pmpro-network' ), $sitename, $sitetitle ) . "\n";
 			$order->saveOrder();
 		}
 	}

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -266,7 +266,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 		}
 	} elseif ( pmpron_getSiteCredits( $order->membership_id ) > 0 ) {
 		$blog_id = pmpron_addSite( $sitename, $sitetitle, $user_id );
-		if ( is_wp_error( $blog_id ) ) {
+		if ( is_wp_error( $blog_id ) || empty( $blog_id ) ) {
 			// Error activating the blog. Write to order notes.
 			/* translators: %1$s: Network Site Name, %2$s: Network Site Title. */
 			$order->notes .= sprintf( __( 'Site creation failed. Site Name: %1$s. Site Title: %2$s.', 'pmpro-network' ), $sitename, $sitetitle );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -190,7 +190,7 @@ add_action('pmpro_checkout_boxes', 'pmpron_pmpro_checkout_boxes');
  * @param MemberOrder $order The order object.
  */
 function pmpron_pmpro_added_order( $order ) {
-	global $current_user, $pmpro_network_non_site_levels;
+	global $pmpro_network_non_site_levels;
 
 	// If we don't have an order, bail.
 	if ( empty( $order ) || empty( $order->id ) ) {
@@ -229,7 +229,7 @@ add_action( 'pmpro_added_order', 'pmpron_pmpro_added_order' );
  * @param MemberOrder $order The order object.
  */
 function pmpron_update_site_after_checkout( $user_id, $order ) {
-	global $current_user, $current_site, $pmpro_network_non_site_levels;
+	global $current_site, $pmpro_network_non_site_levels;
 
 	// If we don't have an order, bail.
 	if ( empty( $order ) || empty( $order->id ) ) {

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -267,12 +267,12 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 		}
 	} elseif ( pmpron_getSiteCredits( $order->membership_id ) > 0 ) {
 		$blog_id = pmpron_addSite( $sitename, $sitetitle, $user_id );
-		if ( is_wp_error( $blog_id ) || empty( $blog_id ) ) {
-			// Error activating the blog. Write to order notes.
-			/* translators: %1$s: Network Site Name, %2$s: Network Site Title. */
-			$order->notes .= sprintf( __( 'Site creation failed. Site Name: %1$s. Site Title: %2$s.', 'pmpro-network' ), $sitename, $sitetitle ) . "\n";
-			$order->saveOrder();
+		if ( is_wp_error( $blog_id ) ) {
+			$order->notes .= sprintf( __( 'Site creation error: %s', 'pmpro-network' ), $blog_id->get_error_message() ) . "\n";
+		} elseif ( empty( $blog_id ) ) {
+			$order->notes .= __( 'Site creation failed: User not found.', 'pmpro-network' ) . "\n";
 		}
+		$order->saveOrder();
 	}
 }
 add_action( 'pmpro_after_checkout', 'pmpron_update_site_after_checkout', 10, 2 );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -264,10 +264,11 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 		$blog_id = pmpron_addSite( $sitename, $sitetitle, $user_id );
 		if ( is_wp_error( $blog_id ) ) {
 			$order->notes .= sprintf( __( 'Site creation error: %s', 'pmpro-network' ), $blog_id->get_error_message() ) . "\n";
+			$order->saveOrder();
 		} elseif ( empty( $blog_id ) ) {
 			$order->notes .= __( 'Site creation failed: User not found.', 'pmpro-network' ) . "\n";
+			$order->saveOrder();
 		}
-		$order->saveOrder();
 	}
 }
 add_action( 'pmpro_after_checkout', 'pmpron_update_site_after_checkout', 10, 2 );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -240,7 +240,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 	// Pull site details from order.
 	$sitename  = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', true );
 	$sitetitle = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', true );
-	$blog_id   = absint( get_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', true ) );
+	$blog_id   = get_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', true );
 
 	// No network site details in the order, bail.
 	if ( empty( $sitename ) && empty( $blog_id ) ) {
@@ -250,7 +250,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 	if ( ! empty( $blog_id ) ) {
 		// Reclaiming, first check that this id is associated with the user.
 		$all_blog_ids = pmpron_getBlogsForUser( $user_id );
-		if ( in_array( $blog_id, $all_blog_ids, true ) ) {
+		if ( in_array( $blog_id, $all_blog_ids ) ) {
 			// Activate the blog.
 			update_blog_status( $blog_id, 'deleted', '0' );
 			do_action( 'activate_blog', $blog_id );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -255,7 +255,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 	if ( ! empty( $blog_id ) ) {
 		// Reclaiming, first check that this id is associated with the user.
 		$all_blog_ids = pmpron_getBlogsForUser( $user_id );
-		if ( in_array( $blog_id, $all_blog_ids ) ) {
+		if ( in_array( $blog_id, $all_blog_ids, true ) ) {
 			// Activate the blog.
 			update_blog_status( $blog_id, 'deleted', '0' );
 			do_action( 'activate_blog', $blog_id );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -178,13 +178,15 @@ function pmpron_pmpro_checkout_boxes()
 add_action('pmpro_checkout_boxes', 'pmpron_pmpro_checkout_boxes');
 
 /**
- * Save site details to order meta when an order is added for a network site level.
+ * Update the user after checkout
  *
- * @since TBD
+ * @since unknown
+ * @since TBD Site details are pulled from $_REQUEST (which PMPro core repopulates from order meta on offsite/delayed checkout returns).
  *
+ * @param int         $user_id The ID of the user who completed checkout.
  * @param MemberOrder $order The order object.
  */
-function pmpron_pmpro_added_order( $order ) {
+function pmpron_update_site_after_checkout( $user_id, $order ) {
 	global $pmpro_network_non_site_levels;
 
 	// If we don't have an order, bail.
@@ -192,57 +194,19 @@ function pmpron_pmpro_added_order( $order ) {
 		return;
 	}
 
-	// If the order level is not set or is in the non site levels array, bail.
-	if ( empty( $order->membership_id ) || ( ( is_array( $pmpro_network_non_site_levels ) && in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) ) ) {
+	// Membership level ID not set, or completed checkout is for a non-network site level, bail.
+	if ( empty( $order->membership_id ) || ( is_array( $pmpro_network_non_site_levels ) && in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) ) {
 		return;
 	}
 
-	// Get site name, site title, and blog id from request.
+	// Pull site details from $_REQUEST. For offsite/delayed checkout flows, PMPro core
+	// repopulates $_REQUEST from order meta via pmpro_pull_checkout_data_from_order()
+	// before pmpro_after_checkout fires.
 	$sitename  = ! empty( $_REQUEST['sitename'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitename'] ) ) : '';
 	$sitetitle = ! empty( $_REQUEST['sitetitle'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['sitetitle'] ) ) : '';
 	$blog_id   = ! empty( $_REQUEST['blog_id'] ) ? absint( $_REQUEST['blog_id'] ) : 0;
 
-	// Save site details to order meta for use later.
-	if ( ! empty( $sitename ) ) {
-		update_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', $sitename );
-	}
-	if ( ! empty( $sitetitle ) ) {
-		update_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', $sitetitle );
-	}
-	if ( ! empty( $blog_id ) ) {
-		update_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', $blog_id );
-	}
-}
-add_action( 'pmpro_added_order', 'pmpron_pmpro_added_order' );
-
-/**
- * Update the user after checkout
- *
- * @since unknown
- * @since TBD Fetching site details from order meta instead of request/session
- *
- * @param int         $user_id The ID of the user who completed checkout.
- * @param MemberOrder $order The order object.
- */
-function pmpron_update_site_after_checkout( $user_id, $order ) {
-	global $current_site, $pmpro_network_non_site_levels;
-
-	// If we don't have an order, bail.
-	if ( empty( $order ) || empty( $order->id ) ) {
-		return;
-	}
-
-	// Membership level ID not set, or completed checkout is for a non-network site level, bail.
-	if ( empty( $order->membership_id ) || ( ( is_array( $pmpro_network_non_site_levels ) && in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) ) ) {
-		return;
-	}
-
-	// Pull site details from order.
-	$sitename  = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', true );
-	$sitetitle = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', true );
-	$blog_id   = get_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', true );
-
-	// No network site details in the order, bail.
+	// No network site details in the request, bail.
 	if ( empty( $sitename ) && empty( $blog_id ) ) {
 		return;
 	}

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -431,7 +431,7 @@ function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 	$blog_id = wpmu_create_blog( $site, $path, $sitetitle, $user->ID, $meta );
 
 	if ( is_a( $blog_id, 'WP_Error' ) ) {
-		return new WP_Error( 'blogcreate_failed', __( '<strong>ERROR</strong>: Site creation failed.' ) );
+		return new WP_Error( 'blogcreate_failed', __( '<strong>ERROR</strong>: Site creation failed.', 'pmpro_network' ) );
 	}
 
 	do_action( 'pmpro_network_new_site', $blog_id, $user->ID );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -245,7 +245,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 	// Pull site details from order.
 	$sitename  = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitename', true );
 	$sitetitle = get_pmpro_membership_order_meta( $order->id, 'pmpron_sitetitle', true );
-	$blog_id   = get_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', true );
+	$blog_id   = absint( get_pmpro_membership_order_meta( $order->id, 'pmpron_blog_id', true ) );
 
 	// No network site details in the order, bail.
 	if ( empty( $sitename ) && empty( $blog_id ) ) {

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -430,11 +430,11 @@ function pmpron_addSite( $sitename, $sitetitle, $user_id = null ) {
 	);
 	$blog_id = wpmu_create_blog( $site, $path, $sitetitle, $user->ID, $meta );
 
-	do_action( 'pmpro_network_new_site', $blog_id, $user->ID );
-
 	if ( is_a( $blog_id, 'WP_Error' ) ) {
 		return new WP_Error( 'blogcreate_failed', __( '<strong>ERROR</strong>: Site creation failed.' ) );
 	}
+
+	do_action( 'pmpro_network_new_site', $blog_id, $user->ID );
 
 	// Save array of all blog ids.
 	$blog_ids = pmpron_getBlogsForUser( $user->ID );

--- a/pmpro-network.php
+++ b/pmpro-network.php
@@ -198,7 +198,7 @@ function pmpron_pmpro_added_order( $order ) {
 	}
 
 	// If the order level is not set or is in the non site levels array, bail.
-	if ( empty( $order->membership_id ) || in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) {
+	if ( empty( $order->membership_id ) || ( ( is_array( $pmpro_network_non_site_levels ) && in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) ) ) {
 		return;
 	}
 
@@ -238,7 +238,7 @@ function pmpron_update_site_after_checkout( $user_id, $order ) {
 	}
 
 	// Membership level ID not set, or completed checkout is for a non-network site level, bail.
-	if ( empty( $order->membership_id ) || in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) {
+	if ( empty( $order->membership_id ) || ( ( is_array( $pmpro_network_non_site_levels ) && in_array( $order->membership_id, $pmpro_network_non_site_levels ) ) ) ) {
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-network/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-network/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Storing member network site details in order meta to better support offsite gateways.

Updating `pmpron_addSite()` with an optional `$user_id` param to make site creation possible for delayed checkouts, e.g PBC, Stripe Checkout webhooks, order recheck function.

Removing PHP session based support for PayPal Express that relied on deprecated `pmpro_paypalexpress_session_vars` hook.

Adding details to order notes on blog creation failure.

Resolves #31 

### How to test the changes in this Pull Request:
1. Complete checkout for a level that gives network sites via Pay By Check, PayPal Express, PayFast, Stripe Checkout...  
2. See that network site is created for the right user on checkout completion.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry